### PR TITLE
Force page reload when closing the modal dialog after a successful up…

### DIFF
--- a/js/html5_upload_progress.js
+++ b/js/html5_upload_progress.js
@@ -105,6 +105,22 @@
 					$(event.target).parent().remove();
 				}
 			});
+			
+			// Force page reload on button "Done" click
+			$(this.input.form).submit(function(e){
+				if(self.success > 0) {					
+					e.preventDefault();
+					window.location.reload();
+					return false;
+				}
+			});
+			
+			// Force page reload after closing the modal dialog
+			$('.ui-dialog-titlebar-close').click(function(e){
+				if(self.success > 0) {					
+					window.location.reload();
+				}
+			});
 
 			this.created = true;
 		},


### PR DESCRIPTION
After uploading images, the page is not updated after closing the upload modal dialog.
We force a full page refresh after clicking on the "Done" button or closing the dialog.